### PR TITLE
feature: add constructors to allow custom http client

### DIFF
--- a/Modio/Client.cs
+++ b/Modio/Client.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using Modio.Models;
@@ -48,6 +49,13 @@ namespace Modio
         /// Initializes a new instance of <see cref="Client"/> with a custom host and <paramref name="credentials"/>.
         /// </summary>
         public Client(Uri baseUrl, Credentials credentials) : this(new Connection(FixBaseUrl(baseUrl), credentials))
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Client"/> with a custom host, custom <paramref name="credentials"/>, and a custom <paramref name="httpClient"/>.
+        /// </summary>
+        public Client(Uri baseUrl, Credentials credentials, HttpClient httpClient) : this(new Connection(FixBaseUrl(baseUrl), credentials, httpClient))
         {
         }
 

--- a/Modio/Http/Connection.cs
+++ b/Modio/Http/Connection.cs
@@ -24,9 +24,13 @@ namespace Modio
 
         public Credentials Credentials { get; set; }
 
-        public Connection(Uri baseAddress, Credentials credentials)
+        public Connection(Uri baseAddress, Credentials credentials) : this(baseAddress, credentials, new HttpClient())
         {
-            http = new HttpClient();
+        }
+
+        public Connection(Uri baseAddress, Credentials credentials, HttpClient httpClient)
+        {
+            http = httpClient;
             BaseAddress = baseAddress;
             Credentials = credentials;
         }


### PR DESCRIPTION
This PR adds the option to pass along a http client of your choosing down to the internal Connection instance. 

This can be useful if you want to add custom handlers or policies to the http client.