### PR TITLE
Add missing event enums

### DIFF
--- a/Modio/Models/Response/Mod.cs
+++ b/Modio/Models/Response/Mod.cs
@@ -475,4 +475,14 @@ public enum ModEventType
     /// A user has joined or left the mod team.
     /// </summary>
     MOD_TEAM_CHANGED,
+
+    /// <summary>
+    /// A new comment was left on the mod.
+    /// </summary>
+    MOD_COMMENT_ADDED,
+
+    /// <summary>
+    /// A comment was deleted from a mod.
+    /// </summary>
+    MOD_COMMENT_DELETED,
 }


### PR DESCRIPTION
mod comment added and deleted have been missing for a few years so this adds them