### PR TITLE
Avoid integer underflow and wasted iterations in ToPagedEnumerable.

### DIFF
--- a/Modio/Clients/SearchClient.cs
+++ b/Modio/Clients/SearchClient.cs
@@ -79,7 +79,8 @@ public class SearchClient<T> : ApiClient where T : class
     public async IAsyncEnumerable<IReadOnlyList<T>> ToPagedEnumerable()
     {
         var (method, path) = this.route;
-        uint? remaining = null;
+        // Avoid integer underflow when 
+        long? remaining = null;
         do
         {
             var req = new Request(method, path);
@@ -92,6 +93,7 @@ public class SearchClient<T> : ApiClient where T : class
 
             remaining ??= result.Total;
             remaining -= result.Count;
+            
 
             var limit = result.Limit;
             var offset = result.Offset;

--- a/Modio/Clients/SearchClient.cs
+++ b/Modio/Clients/SearchClient.cs
@@ -94,6 +94,10 @@ public class SearchClient<T> : ApiClient where T : class
             remaining ??= result.Total;
             remaining -= result.Count;
 
+            // Don't bother returning anything or continuing for an empty response
+            if (result.Count == 0)
+                yield break;
+
             var limit = result.Limit;
             var offset = result.Offset;
 

--- a/Modio/Clients/SearchClient.cs
+++ b/Modio/Clients/SearchClient.cs
@@ -79,7 +79,7 @@ public class SearchClient<T> : ApiClient where T : class
     public async IAsyncEnumerable<IReadOnlyList<T>> ToPagedEnumerable()
     {
         var (method, path) = this.route;
-        // Avoid integer underflow when 
+        // Huge integer type that does signed arithmetic and encompasses uint's max value
         long? remaining = null;
         do
         {
@@ -93,7 +93,6 @@ public class SearchClient<T> : ApiClient where T : class
 
             remaining ??= result.Total;
             remaining -= result.Count;
-            
 
             var limit = result.Limit;
             var offset = result.Offset;

--- a/Modio/Models/Response/Mod.cs
+++ b/Modio/Models/Response/Mod.cs
@@ -475,4 +475,14 @@ public enum ModEventType
     /// A user has joined or left the mod team.
     /// </summary>
     MOD_TEAM_CHANGED,
+
+    /// <summary>
+    /// A new comment was left on the mod.
+    /// </summary>
+    MOD_COMMENT_ADDED,
+
+    /// <summary>
+    /// A comment was deleted from a mod.
+    /// </summary>
+    MOD_COMMENT_DELETED,
 }


### PR DESCRIPTION
SearchClient.ToPagedEnumerable can underflow `remaining` if `result.Total` and `result.Count` are different (particularly, if count is greater than total), leading to the paginator asking for a bunch of empty pages at absurd offsets.

This has actually happened, as a heap dump from a running bot confirmed that the `remaining` variable was `0xFFFFFFFE` (`4,294,967,294` in decimal, or `0 - 2` in math).

And to avoid wasting iterations on empty responses, in case someone intentionally puts a huge `offset` in, just `yield break` when receiving an empty count.